### PR TITLE
Emitting version file instead of writing it

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,8 +74,7 @@ VersionFile.prototype.emitFile = function(templateContent, compilation) {
   compilation.hooks.processAssets.tap(
       {
         name: 'WebpackVersionFilePlugin',
-        stage: compilation.PROCESS_ASSETS_STAGE_ADDITIONAL,
-        additionalAssets: true
+        stage: compilation.PROCESS_ASSETS_STAGE_ADDITIONAL
       },
       (assets) => {
         compilation.emitAsset(


### PR DESCRIPTION
I'm proposing to emit the version file instead of writing it to disk,

the motivation for this change is the fact that writing the file makes it unavailable when serving, and also write an orphan file, with no other assets, because they are only in memory. 

The file will be written on disk when building and can still be written to disk when using `devServer.devMiddleware.writeToDisk` option, like any other assets.

thanks